### PR TITLE
[Enhancement] passthru url checking options to downstream action

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Will check for the status of the PR environment. Once available will retrieve th
 and then begin a visual regression test between the production environment and PR environment. If the visual regression
 test fails, will create a comment in the PR with a link to the visual regression report.
 
+Note that this action assumes it is ok to check the PR environment even if a valid certificate has not been issued when testing begins.
+
 ## Inputs
 * `github-token` - **REQUIRED**. Github [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with 
 access rights to the target repository so we can work with the github api. You can reuse the default `GITHUB_TOKEN` that's created for the runner.

--- a/action.yaml
+++ b/action.yaml
@@ -89,7 +89,9 @@ runs:
         baseline_url: ${{ inputs.baseline-url }}
         test_url: ${{ steps.get-target-url.outputs.target_url }}
         report_results: true
-
+        # often the cert provisioning hasn't completed for a PR environment before we begin testing. This causes curl
+        # to error with an exit code of 60
+        test_url_insecure: true
     # If the VRT Test failed we want to create a comment on the PR to check the artifact created by the VRT
     - name: 'Comment on PR'
       id: comment-on-failed-PR


### PR DESCRIPTION
Adds `test_url_insecure` to options passed to VRT action so that the tests will not fail if a valid certificate has not been provisioned before testing begins. Closes #5 

This will need to be merged AFTER this pull request. https://github.com/platformsh/gha-visual-regression-testing/pull/14